### PR TITLE
Fix navigation and team list loading

### DIFF
--- a/RATSApp/main.py
+++ b/RATSApp/main.py
@@ -188,8 +188,21 @@ class SelectOffenceScreen(Screen):
         sApp.root.ids.rsm.current = 'select_players'
         return True
 
+    def go_back(self, *args):
+        sApp = App.get_running_app()
+        sApp.unordered_teams = []
+        sApp.root.ids.rsm.current = 'team_select'
+        return True
+
 
 class SelectPlayersScreen(Screen):
+    def on_leave(self, *args):
+        # Clear dynamic widgets to avoid duplicates on re-entry
+        self.ids.LeftBox.clear_widgets()
+        self.ids.RightBox.clear_widgets()
+        self.ids.LeftBox.add_widget(Label(text='Offence'))
+        self.ids.RightBox.add_widget(Label(text='Defence'))
+
     def on_pre_enter(self, *args):
 
         sApp = App.get_running_app()
@@ -348,6 +361,13 @@ class SelectPlayersScreen(Screen):
 
 
 class PullingScreen(Screen):
+    def on_leave(self, *args):
+        # Clear dynamic widgets to avoid duplicates on re-entry
+        self.ids.LeftBox.clear_widgets()
+        self.ids.RightBox.clear_widgets()
+        self.ids.LeftBox.add_widget(Label(text='Available Players'))
+        self.ids.RightBox.add_widget(Label(text='Available Outcomes'))
+
     def on_pre_enter(self, *args):
 
         sApp = App.get_running_app()
@@ -391,8 +411,17 @@ class PullingScreen(Screen):
 
         return True
 
+    def go_back(self, *args):
+        sApp = App.get_running_app()
+        sApp.current_point = None
+        sApp.root.ids.rsm.current = 'select_players'
+        return True
+
 
 class PlayBreakScreen(Screen):
+    def on_leave(self, *args):
+        # Clear dynamic widgets to avoid duplicates on re-entry
+        self.ids.BigBox.clear_widgets()
 
     def on_pre_enter(self, *args):
         sApp = App.get_running_app()
@@ -619,6 +648,12 @@ class PlayBreakScreen(Screen):
 
 
 class SelectActionScreen(Screen):
+    def on_leave(self, *args):
+        # Clear dynamic widgets to avoid duplicates on re-entry
+        self.ids.LeftBox.clear_widgets()
+        self.ids.RightBox.clear_widgets()
+        self.ids.LeftBox.add_widget(Label(text='Available Players'))
+        self.ids.RightBox.add_widget(Label(text='Available Actions'))
 
     def on_pre_enter(self, *args):
 
@@ -904,6 +939,9 @@ class SelectActionScreen(Screen):
 
 # this is where you can select a game file and continue on from the end
 class ChooseStatsScreen(Screen):
+    def on_leave(self, *args):
+        # Clear dynamic widgets to avoid duplicates on re-entry
+        self.ids.BigBox.clear_widgets()
 
     def on_pre_enter(self, *args):
         sApp = App.get_running_app()
@@ -939,9 +977,17 @@ class ChooseStatsScreen(Screen):
 
         sApp.root.ids.rsm.current = 'select_players'
 
+    def go_back(self, *args):
+        sApp = App.get_running_app()
+        sApp.root.ids.rsm.current = 'menu'
+        return True
+
 # strictly experimental - don't go here
 
 class ReadScreen(Screen):
+    def on_leave(self, *args):
+        # Clear dynamic widgets to avoid duplicates on re-entry
+        self.ids.BigBox.clear_widgets()
 
     def on_pre_enter(self):
         sApp = App.get_running_app()
@@ -971,6 +1017,10 @@ class ExportScreen(Screen):
         # here i want to come in and have you choose which game to export
         # then export the basic stats to a csv file
         # then upload that to our gdrive
+
+    def on_leave(self, *args):
+        # Clear dynamic widgets to avoid duplicates on re-entry
+        self.ids.BigBox.clear_widgets()
 
     def on_pre_enter(self, *args):
         sApp = App.get_running_app()

--- a/RATSApp/main.py
+++ b/RATSApp/main.py
@@ -109,8 +109,9 @@ class TeamSelectScreen(Screen):
 
     def __init__(self,**kwargs):
         super(TeamSelectScreen,self).__init__(**kwargs)
-        sApp = App.get_running_app()
-        self.teamlistpath = os.path.join(sApp.user_data_dir, 'teamlists'.strip())
+        # Use the app directory for teamlists, not user_data_dir
+        app_dir = os.path.dirname(os.path.abspath(__file__))
+        self.teamlistpath = os.path.join(app_dir, 'teamlists')
 
     def on_pre_enter(self, *args):
         sApp = App.get_running_app()

--- a/RATSApp/stats.kv
+++ b/RATSApp/stats.kv
@@ -257,7 +257,14 @@ BoxLayout:
         spacing:20
         id:BigBox
 
-        #Label:
+    BoxLayout:
+        orientation:'horizontal'
+        padding:[40,40,40,40]
+        spacing:20
+        size_hint_y:0.15
+        MDRaisedButton:
+            text:'Back'
+            on_release:root.go_back()
 
 <ReadScreen>
     name:'read_stats'
@@ -343,12 +350,6 @@ BoxLayout:
             text:'Which team is on offence:'
             halign:'center'
             font_style: 'H6'
-            #canvas.before:
-            #    Color:
-            #        rgba: 1, 0, 0, 1  # red
-            #    Rectangle:
-            #        pos: self.pos
-            #        size: self.size
 
         MDRaisedButton:
             id:topbutton
@@ -363,6 +364,12 @@ BoxLayout:
             pos_hint:{'center_x':0.5}
             text:'undef_Bottom'
             on_release:root.store_offence(self.text)
+
+        MDRaisedButton:
+            text:'Back'
+            size_hint:(0.3,0.1)
+            pos_hint:{'center_x':0.5}
+            on_release:root.go_back()
 
 <SelectPlayersScreen>
     name:'select_players'
@@ -440,6 +447,13 @@ BoxLayout:
                 MDLabel:
                     text:'Available Outcomes'
                     size_hint_y:0.25
+        BoxLayout:
+            orientation:'horizontal'
+            padding:[40,10,40,10]
+            size_hint_y:0.1
+            MDRaisedButton:
+                text:'Back'
+                on_release:root.go_back()
 
 <SelectActionScreen>
     name:'select_action'

--- a/RATSApp/stats.kv
+++ b/RATSApp/stats.kv
@@ -309,11 +309,13 @@ BoxLayout:
             id:filechA
             path:root.teamlistpath
             size_hint_x:0.5
+            filters:['*.txt']
 
         FileChooserListView:
             id:filechB
             path:root.teamlistpath
             size_hint_x:0.5
+            filters:['*.txt']
 
     BoxLayout:
         orientation:'horizontal'

--- a/RATSApp/teamlists/Australia.txt
+++ b/RATSApp/teamlists/Australia.txt
@@ -1,0 +1,3 @@
+name: Australia
+staff: Coach A,Manager B
+players: 1|M|Player One,2|F|Player Two,3|M|Player Three,4|F|Player Four,5|M|Player Five,6|F|Player Six,7|M|Player Seven,8|F|Player Eight,9|M|Player Nine,10|F|Player Ten,11|M|Player Eleven,12|F|Player Twelve,13|M|Player Thirteen,14|F|Player Fourteen

--- a/RATSApp/teamlists/Japan.txt
+++ b/RATSApp/teamlists/Japan.txt
@@ -1,0 +1,3 @@
+name: Japan
+staff: Coach X,Manager Y
+players: 1|M|Yamada Taro,2|F|Tanaka Yuki,3|M|Suzuki Ken,4|F|Sato Mika,5|M|Ito Hiroshi,6|F|Watanabe Aiko,7|M|Takahashi Ryo,8|F|Nakamura Yui,9|M|Kobayashi Kenji,10|F|Kato Sakura,11|M|Yoshida Takeshi,12|F|Yamamoto Emi,13|M|Sasaki Daiki,14|F|Matsumoto Hana


### PR DESCRIPTION
## Summary
- Add back navigation buttons to screens that were dead ends (SelectOffenceScreen, ChooseStatsScreen, PullingScreen)
- Fix team list loading to use bundled teamlists folder instead of user_data_dir
- Add .txt file filter to team selection file choosers
- Add sample Australia and Japan team files for testing
- Prevent widget duplication when navigating between screens

## Issues Fixed
- Closes #2 (Menu Interfacing)
- Closes #3 (Loading team lists)

## Test Plan
- [x] Built and installed APK on Android device
- [ ] Verify back buttons work on all screens
- [ ] Verify team list files load correctly